### PR TITLE
Allows usage of hash and query params in asset-url function

### DIFF
--- a/source/sass/sass_extensions/functions/asset_url.rb
+++ b/source/sass/sass_extensions/functions/asset_url.rb
@@ -1,10 +1,15 @@
+require 'uri'
+
 module SassExtensions::Functions
 
   # Return an absolute URL to the named file
   def asset_url(filename)
     assert_type filename, :String
-    url_to_asset = SassExtensions::AssetManager.absolute_url_to(filename.value)
-    Sass::Script::String.new("url('#{ url_to_asset }')")
+    # Store passed filename into and URI instance:
+    uri = URI.parse(filename.value)
+    # Process the path part of the URI instance:
+    uri.path = SassExtensions::AssetManager.absolute_url_to(uri.path)
+    Sass::Script::String.new("url('#{ url.to_s }')")
   end
 
   Sass::Script::Functions.declare :asset_url, args: [:filename]

--- a/source/sass/sass_extensions/functions/asset_url.rb
+++ b/source/sass/sass_extensions/functions/asset_url.rb
@@ -9,7 +9,7 @@ module SassExtensions::Functions
     uri = URI.parse(filename.value)
     # Process the path part of the URI instance:
     uri.path = SassExtensions::AssetManager.absolute_url_to(uri.path)
-    Sass::Script::String.new("url('#{ url.to_s }')")
+    Sass::Script::String.new("url('#{ uri.to_s }')")
   end
 
   Sass::Script::Functions.declare :asset_url, args: [:filename]


### PR DESCRIPTION
Now `asset-url` can take as it's argument not only bare paths, but also such things as the following:
- `path/filename.ext#hash`
- `path/filename.ext?key=value`

etc.
