### PR TITLE
use "build.ngseed.dev" domain for build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,6 +63,9 @@ gulp.task('copy', ['sass'], function () {
     gulp.src(['source/js/config-require.js'])
       .pipe(uglify().on('error', handleError))
       .pipe(gulp.dest('build/js')),
+    // copy template files
+    gulp.src(['source/js/**/*.html'])
+      .pipe(gulp.dest('build/js')),
     // copy vendor files
     gulp.src(['source/vendor/**/*'])
       .pipe(gulp.dest('build/vendor')),

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -1,14 +1,29 @@
-# https://github.com/h5bp/server-configs-nginx
 
+
+# development config ('build' subdomain goes to /build, otherwise to /source)
+map $subdomain $root_folder {
+  default source;
+  'build' build;
+}
+
+
+# production config ('debug' subdomain goes to /source, otherwise to /build)
+#map $subdomain $root_folder {
+#  default build;
+#  'debug' source;
+#}
+
+
+# https://github.com/h5bp/server-configs-nginx
 server {
   listen 80;
-  server_name ngseed.dev;
+  server_name ~^(?P<subdomain>.+?)?\.?ngseed\.dev$;
 
   # @FIXME update this path with yours
   set $host_path "{{ABSOLUTE_PATH_TO_PROJECT_SOURCE}}";
 
   # Path for static files
-  root $host_path/source;
+  root $host_path/$root_folder;
 
   # Locations go before directives for easier reading
 

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -1,5 +1,3 @@
-
-
 # development config ('build' subdomain goes to /build, otherwise to /source)
 map $subdomain $root_folder {
   default source;


### PR DESCRIPTION
http://ngseed.dev -> /source
http://build.ngseed.dev -> /build

 **TODO** use html2js for templates (seems like we need to update [gulp-html2js](https://github.com/fraserxu/gulp-html2js/blob/master/lib/compile.js) in order to support `fileHeaderString` and `fileFooterString` options).
