### PR TITLE
chore(build process): end the process with exit code 1 instead of 0

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -18,7 +18,7 @@ var webdriver = require('gulp-protractor').webdriver_standalone;
 
 var handleError = function (err) {
   console.log(err.name, ' in ', err.plugin, ': ', err.message);
-  this.emit('end');
+  process.exit(1);
 };
 
 // Bump version


### PR DESCRIPTION
This is especially important for CI. Right now if tests fail the build process will run through exiting with 0 & continue deploying.
